### PR TITLE
feat: Shorten overly long songs for better memorization

### DIFF
--- a/index.html
+++ b/index.html
@@ -327,7 +327,7 @@ const songs = [
             {note: 'C', duration: 'eighth'}, {note: 'D', duration: 'eighth'}, {note: 'E', duration: 'quarter'}, {note: 'C', duration: 'quarter'},
             {note: 'E', duration: 'eighth'}, {note: 'F', duration: 'eighth'}, {note: 'G', duration: 'half'},
             {note: 'G', duration: 'eighth'}, {note: 'A', duration: 'eighth'}, {note: 'G', duration: 'quarter'}, {note: 'F', duration: 'quarter'},
-            {note: 'E', duration: 'eighth'}, {note: 'C', duration: 'eighth'}, {note: 'D', duration: 'quarter'}, {note: 'C', duration: 'half'}
+            {note: 'E', duration: 'eighth'}, {note: 'C', duration: 'eighth'}, {note: 'D', duration: 'quarter'}
         ],
         tempo: 400
     },
@@ -339,9 +339,7 @@ const songs = [
             {note: 'E', duration: 'dotted_quarter'}, {note: 'D', duration: 'eighth'}, {note: 'E', duration: 'dotted_quarter'}, {note: 'F', duration: 'eighth'},
             {note: 'G', duration: 'half'},
             {note: 'c', duration: 'eighth'}, {note: 'c', duration: 'eighth'}, {note: 'c', duration: 'eighth'},
-            {note: 'G', duration: 'eighth'}, {note: 'G', duration: 'eighth'}, {note: 'G', duration: 'eighth'},
-            {note: 'E', duration: 'eighth'}, {note: 'E', duration: 'eighth'}, {note: 'E', duration: 'eighth'},
-            {note: 'C', duration: 'eighth'}, {note: 'C', duration: 'eighth'}, {note: 'C', duration: 'eighth'}
+            {note: 'G', duration: 'eighth'}
         ],
         tempo: 420
     },


### PR DESCRIPTION
I modified the `songs` array in `index.html` to reduce the length of songs that were considered too long, making them easier for you to memorize and play.

- "Row Row Row Your Boat" has been shortened from 22 notes to its first 14 notes.
- "Pop Goes the Weasel" has been shortened from 15 notes to its first 14 notes.

This change aims to improve playability by ensuring all songs have a more consistent and manageable length, using "Jingle Bells" (11 notes) and "Twinkle Twinkle" (14 notes) as benchmarks for reasonable length.